### PR TITLE
Changes for new Lustre on Young+Michael

### DIFF
--- a/lquota
+++ b/lquota
@@ -636,13 +636,6 @@ function __main() {
             local -A pools=([lustre]="/scratch")
             local default_pool="lustre"
             ;;
-        "michael")
-            msg debug "using settings for michael"
-            # Ditto for michael
-            local quota_mode="user"
-            local -A pools=([lustre]="/scratch")
-            local default_pool="lustre"
-            ;;
         "kathleen")
             msg debug "using settings for kathleen"
             # Kathleen's new Lustre uses project quotas,
@@ -651,12 +644,12 @@ function __main() {
             local -A pools=([lustre]="/home/%username%")
             local default_pool="lustre"
             ;;
-        "young")
-            msg debug "using settings for young"
-            # Young's Lustre uses ZFS which didn't support project quotas initially
-            local quota_mode="user"
-            local -A pools=([lustre]="/home/%username%")
-            local default_pool="lustre"
+        "young"|"michael")
+            msg debug "using settings for young+michael"
+            # Young and Michael now share one Lustre filesystem
+            local quota_mode="project"
+            local -A pools=([home]="/home/%username%" [scratch]="/scratch/%username%")
+            local default_pool="scratch"
             ;;
         *)
     esac

--- a/remove_old_moduledirs
+++ b/remove_old_moduledirs
@@ -15,7 +15,10 @@ if (whoami | grep -v ccspapp); then
 EOF
   exit
 fi
-  
+
+# Check if there's a common apps area (e.g. merged Young/Michael)
+[[ -d "${moduledirs_path}/../common" ]] \
+&& moduledirs_path="${moduledirs_path}/../common"
 
 # v-- gets a list of all directories named .mf_* created more than 7 days ago
 dirs_to_remove=`find -L $moduledirs_path -maxdepth 1 -type d -name ".mf_*" -ctime +7`

--- a/update_modules
+++ b/update_modules
@@ -99,6 +99,12 @@ if [[ ! -L "modulefiles" ]]; then
   fi
 fi
 
+# Check if there's a common apps area (e.g. merged Young/Michael)
+if [[ -d ../common ]]; then
+  ln -Tfs ../common/modulefiles modulefiles
+  cd ../common
+  moduledirs_path="$PWD"
+fi
 
 # Repo config info
 

--- a/update_modules
+++ b/update_modules
@@ -37,7 +37,7 @@ fi
 
 scriptname="$(basename "$0")"
 usage="
-Usage: $scriptname [-h] [-f|-i] [-r]
+Usage: $scriptname [-h] [-f|-i] [-k]
 
     -h  Prints this help
     -f  Force update even if it would be the same


### PR DESCRIPTION
This PR includes two changes:

a) On the new Lustre we have switched to project quotas (similar to Kathleen).

b) As Young+Michael now share a common Lustre filesystem, there was some rearrangement to the apps area. We now have /shared/ucl/apps pointing to an architecture-specific apps directory (`avx512` or `avx2` for now). But having separate modulefiles directories in both is cumbersome and error-prone. Therefore the `modulefiles` link in the arch-specific directories points to a location in a `common` area. The scripts for updating the modulefiles have been augmented with some logic to handle this situation.