### PR TITLE
More Slurm support

### DIFF
--- a/checkuser
+++ b/checkuser
@@ -124,7 +124,6 @@ function slurm_check_accounts() {
     done
 }
 
-
 function sge_check_access () {
     local username="$1"
     local pam_listfile="/var/opt/sge/shared/userlist"
@@ -136,6 +135,40 @@ function sge_check_access () {
     fi
     if grep "^$username\$" "$pam_listfile" >/dev/null; then
         echo "${GREEN}yes${RESET}"
+    else
+        echo "${RED}no${RESET}"
+    fi
+}
+
+function slurm_check_access () {
+    local username="$1"
+    local clustername="$(/shared/ucl/sysops/libexec/clustname 2>/dev/null || true)"
+    local pag
+    local user_groups
+
+    echo -n "Checking whether user is in the platform access group: "
+    if [[ -z "$clustername" ]]; then
+        echo "${RED}cannot determine cluster${RESET}"
+        return
+    fi
+    case "$clustername" in
+        myriad)   pag='pag-archpc-myriad' ;;
+        kathleen) pag='pag-archpc-kathleen' ;;
+        young)    pag='pag-archpc-young' ;;
+        michael)  pag='pag-archpc-michael' ;;
+        dev-*)    pag='pag-archpc-hydra' ;;
+        *)
+            echo "${RED}unknown cluster \"$clustername\"${RESET}"
+            return
+            ;;
+    esac
+    if user_groups="$(groups "$username" 2>&1)"; then
+        user_groups="${user_groups#*:}"
+        if fgrep -qw "$pag" <<< "$user_groups"; then
+            echo "${GREEN}yes${RESET} ($pag)"
+        else
+            echo "${RED}no${RESET}"
+        fi
     else
         echo "${RED}no${RESET}"
     fi
@@ -158,6 +191,7 @@ if [[ -n "$have_sge" ]]; then
 elif [[ -n "$have_slurm" ]]; then
     slurm_check_user_exists "$username"
     slurm_check_accounts "$username"
+    slurm_check_access "$username"
 fi
 
 

--- a/checkuser
+++ b/checkuser
@@ -272,13 +272,32 @@ fi
 
 echo ""
 
-echo -n "Checking whether user has jobs in the queue: "
-has_jobs="$(qstat -u "$username" | wc -l)"
-if [ "$has_jobs" -gt 0 ]
-then
-  echo "${GREEN}yes${RESET}"
-else
-  echo "${BLUE}no${RESET}"
+function sge_check_jobs () {
+    local username="$1"
+    echo -n "Checking whether user has jobs in the queue: "
+    num_jobs="$(qstat -u "$username" | wc -l)"
+    if [ "$num_jobs" -gt 0 ]; then
+        echo "${GREEN}yes${RESET}"
+    else
+        echo "${BLUE}no${RESET}"
+    fi
+}
+
+function slurm_check_jobs () {
+    local username="$1"
+    echo -n "Checking whether user has jobs in the queue: "
+    num_jobs="$(squeue --noheader --user="$username" --Format='JobID' 2>/dev/null || true)"
+    if [ "$num_jobs" -gt 0 ]; then
+        echo "${GREEN}yes${RESET}"
+    else
+        echo "${BLUE}no${RESET}"
+    fi
+}
+
+if [[ -n "$have_sge" ]]; then
+    sge_check_jobs "$username"
+elif [[ -n "$have_slurm" ]]; then
+    slurm_check_jobs "$username"
 fi
 
 echo -n "Checking when user last logged in to this node: "
@@ -288,5 +307,4 @@ if [ -z "$last_login" ]; then
 else
     echo "${BLUE}$last_login${RESET}"
 fi
-
 

--- a/checkuser
+++ b/checkuser
@@ -106,11 +106,18 @@ function slurm_check_user_exists() {
     fi
 }
 
-
+have_sge=""
+have_slurm=""
 if command -v qconf >/dev/null; then
+    have_sge='yes'
+elif command -v sacctmgr >/dev/null; then
+    have_slurm='yes'
+fi
+
+if [[ -n "$have_sge" ]]; then
     sge_check_acls "$username"
     sge_check_nosub "$username"
-elif command -v sacctmgr >/dev/null; then
+elif [[ -n "$have_slurm" ]]; then
     slurm_check_user_exists "$username"
 fi
 

--- a/checkuser
+++ b/checkuser
@@ -286,7 +286,7 @@ function sge_check_jobs () {
 function slurm_check_jobs () {
     local username="$1"
     echo -n "Checking whether user has jobs in the queue: "
-    num_jobs="$(squeue --noheader --user="$username" --Format='JobID' 2>/dev/null || true)"
+    num_jobs="$(squeue --noheader --user="$username" --Format='JobID' 2>/dev/null | wc -l)"
     if [ "$num_jobs" -gt 0 ]; then
         echo "${GREEN}yes${RESET}"
     else

--- a/checkuser
+++ b/checkuser
@@ -106,6 +106,40 @@ function slurm_check_user_exists() {
     fi
 }
 
+function slurm_check_accounts() {
+    local username="$1"
+    local account
+    local -a check_accounts=(allusers)
+    local user_accounts="$(sacctmgr show assoc where user="$username" --noheader format='account%-40')"
+
+    for account in "${check_accounts[@]}"; do
+        echo -n "Checking whether user is in account \"${slurm_account_desc}\": "
+        if fgrep -qw "${account}" <<< "${user_accounts}"; then
+            echo "${GREEN}yes${RESET}"
+        else
+            echo "${RED}no${RESET}"
+        fi
+    done
+}
+
+
+function sge_check_access () {
+    local username="$1"
+    local pam_listfile="/var/opt/sge/shared/userlist"
+
+    echo -n "Checking whether user is in the actual PAM userlist: "
+    if [[ ! -r "$pam_listfile" ]]; then
+        echo "${RED}error${RESET}"
+        return
+    fi
+    if grep "^$username\$" "$pam_listfile" >/dev/null; then
+        echo "${GREEN}yes${RESET}"
+    else
+        echo "${RED}no${RESET}"
+    fi
+}
+
+
 have_sge=""
 have_slurm=""
 if command -v qconf >/dev/null; then
@@ -114,24 +148,16 @@ elif command -v sacctmgr >/dev/null; then
     have_slurm='yes'
 fi
 
+
 if [[ -n "$have_sge" ]]; then
     sge_check_acls "$username"
     sge_check_nosub "$username"
+    sge_check_access "$username"
 elif [[ -n "$have_slurm" ]]; then
     slurm_check_user_exists "$username"
+    slurm_check_accounts "$username"
 fi
 
-
-echo -n "Checking whether user is in the actual PAM userlist: "
-pam_listfile="/var/opt/sge/shared/userlist"
-if [[ ! -r "$pam_listfile" ]]; then
-    echo "${RED}error${RESET}"
-fi
-if grep "^$username\$" "$pam_listfile" >/dev/null; then
-    echo "${GREEN}yes${RESET}"
-else
-    echo "${RED}no${RESET}"
-fi
 
 echo "" # Blank line for section separation
 

--- a/checkuser
+++ b/checkuser
@@ -109,11 +109,13 @@ function slurm_check_user_exists() {
 function slurm_check_accounts() {
     local username="$1"
     local account
+    local account_desc
     local -a check_accounts=(allusers)
     local user_accounts="$(sacctmgr show assoc where user="$username" --noheader format='account%-40')"
 
     for account in "${check_accounts[@]}"; do
-        echo -n "Checking whether user is in account \"${slurm_account_desc}\": "
+        account_desc="$(sacctmgr show account "$account" --json | jq -r '.accounts[].description')"
+        echo -n "Checking whether user is in account ${account} (${account_desc}): "
         if fgrep -qw "${account}" <<< "${user_accounts}"; then
             echo "${GREEN}yes${RESET}"
         else

--- a/createuser
+++ b/createuser
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o nounset
 
 export LC_ALL=C
 
@@ -14,13 +15,14 @@ then
     echo "Run \"createuser userid\"" 1>&2
     exit 1
 fi 
+username="$1"
 
 # Check that the userid starts with a letter and is alphanumeric, 7 chars
-if echo "$1" | grep -qE '^[[:lower:]][[:lower:][:digit:]]{6}$' ;
+if echo "$username" | grep -qE '^[[:lower:]][[:lower:][:digit:]]{6}$' ;
 then
-    echo "Valid user string: $1" 1>&2
+    echo "Valid user string: ${username}" 1>&2
 else
-    echo "Invalid user string: $1" 1>&2
+    echo "Invalid user string: ${username}" 1>&2
     echo "Run \"createuser userid\"" 1>&2
     exit 1
 fi 
@@ -64,13 +66,13 @@ case "$cluster_name" in
         ;;
 esac
 
-echo "creating account for $1"
+echo "creating account for ${username}"
 if command -v qconf >/dev/null; then
     if [[ -z "$SGE_ACL" ]]; then
         echo "Error: detected SGE, but this cluster is not supposed to run SGE." >&2
         exit 1
     fi
-    qconf -au "$1" "$SGE_ACL"
+    qconf -au "${username}" "$SGE_ACL"
 elif command -v sacctmgr >/dev/null; then
     if [[ -z "${slurm_account}" ]]; then
         echo "Error: detected Slurm, but this cluster is not supposed to run Slurm." >&2
@@ -82,7 +84,7 @@ else
     exit 1
 fi
 
-RECIPIENT=$1@ucl.ac.uk
+RECIPIENT="${username}@ucl.ac.uk"
 echo "Emailing user ${RECIPIENT}"
 /usr/sbin/sendmail -t<<EOF
 From: rc-support@ucl.ac.uk

--- a/createuser
+++ b/createuser
@@ -5,7 +5,7 @@ set -e
 export LC_ALL=C
 
 cluster_name="${CLUSTER_NAME:-}"
-ACL=""
+SGE_ACL=""
 
 # Make sure we have a userid to create
 if [ "$#" -ne "1" ];
@@ -43,10 +43,10 @@ fi
 
 case "$cluster_name" in
     "kathleen")
-        ACL="Open"
+        SGE_ACL="Open"
         ;;
     "myriad")
-        ACL="Open"
+        SGE_ACL="Open"
         ;;
     "michael"|"young")
         echo "Error: this is not the correct way to add users to the Thomas and Michael clusters." >&2
@@ -60,7 +60,7 @@ esac
 
 echo "creating account for $1"
 if command -v qconf >/dev/null; then
-    qconf -au "$1" "$ACL"
+    qconf -au "$1" "$SGE_ACL"
 elif command -v sacctmgr >/dev/null; then
     echo "Slurm user adding is not yet implemented since the details of cluster implementation have not yet been finalised."
     echo "You'll need the sacctmgr command, probably something like this:"

--- a/createuser
+++ b/createuser
@@ -33,10 +33,8 @@ if [[ -n "$cluster_name" ]]; then
     # Allow overriding cluster_name for testing/whatever
     echo "Warning: cluster name overridden as \"$cluster_name\"" >&2
     cluster_name="$cluster_name"
-elif [[ -r /opt/sge/default/common/cluster_name ]]; then
-    cluster_name="$(cat /opt/sge/default/common/cluster_name)"
-elif command -v sacctmgr >/dev/null; then
-    cluster_name="$(sacctmgr -pn list cluster | cut -f 1 -d '|')"
+elif [[ -x /shared/ucl/sysops/libexec/clustname ]]; then
+    cluster_name="$(/shared/ucl/sysops/libexec/clustname)"
 elif [[ -r /shared/ucl/etc/cluster_name ]]; then
     cluster_name="$(cat /shared/ucl/etc/cluster_name)"
 else

--- a/createuser
+++ b/createuser
@@ -77,10 +77,6 @@ elif command -v sacctmgr >/dev/null; then
         exit 1
     fi
     sacctmgr --immediate --quiet add user name="${username}" defaultaccount="${slurm_account}"
-    if [[ $? -ne 0 ]]; then
-        echo "Error: could not add Slurm user - are you a Slurm operator?" >&2
-        exit 1
-    fi
 else
     echo "Error: no mechanism for adding users found." >&2
     exit 1

--- a/createuser
+++ b/createuser
@@ -42,19 +42,13 @@ else
 fi
 
 case "$cluster_name" in
-    "grace")
-        ACL="Open"
-        ;;
-    "legion")
-        ACL="Open"
-        ;;
     "kathleen")
         ACL="Open"
         ;;
     "myriad")
         ACL="Open"
         ;;
-    "thomas"|"michael"|"young")
+    "michael"|"young")
         echo "Error: this is not the correct way to add users to the Thomas and Michael clusters." >&2
         exit 1
         ;;
@@ -63,25 +57,6 @@ case "$cluster_name" in
         exit 1
         ;;
 esac
-
-if [[ "$cluster_name" == "legion" ]]; then
-    echo "Reminder: new accounts unassociated with existing paid projects 
-          are no longer to be created on Legion (as of 2019-01-01). "
-    read -r -p "Are you sure you want to create this account? Please type 'yes' if so: " response
-    if [[ "$response" != "yes" ]]; then
-        echo "Okay, stopping."
-        exit
-    fi
-fi
-
-if [[ "$cluster_name" == "grace" ]]; then
-    echo "Reminder: new accounts are no longer to be created on Grace."
-    read -r -p "Are you sure you want to create this account? Please type 'yes' if so: " response
-    if [[ "$response" != "yes" ]]; then
-        echo "Okay, stopping."
-        exit
-    fi
-fi
 
 echo "creating account for $1"
 if command -v qconf >/dev/null; then

--- a/createuser
+++ b/createuser
@@ -6,6 +6,7 @@ export LC_ALL=C
 
 cluster_name="${CLUSTER_NAME:-}"
 SGE_ACL=""
+slurm_account=""
 
 # Make sure we have a userid to create
 if [ "$#" -ne "1" ];
@@ -44,9 +45,14 @@ fi
 case "$cluster_name" in
     "kathleen")
         SGE_ACL="Open"
+        slurm_account="allusers"
         ;;
     "myriad")
         SGE_ACL="Open"
+        slurm_account="allusers"
+        ;;
+    dev-*)
+        slurm_account="allusers"
         ;;
     "michael"|"young")
         echo "Error: this is not the correct way to add users to the Thomas and Michael clusters." >&2
@@ -60,15 +66,21 @@ esac
 
 echo "creating account for $1"
 if command -v qconf >/dev/null; then
+    if [[ -z "$SGE_ACL" ]]; then
+        echo "Error: detected SGE, but this cluster is not supposed to run SGE." >&2
+        exit 1
+    fi
     qconf -au "$1" "$SGE_ACL"
 elif command -v sacctmgr >/dev/null; then
-    echo "Slurm user adding is not yet implemented since the details of cluster implementation have not yet been finalised."
-    echo "You'll need the sacctmgr command, probably something like this:"
-    echo ""
-    echo "  sacctmgr add user name=\"\$username\""
-    echo ""
-    echo "You'll also need at least Operator privileges on Slurm. (Or sudo access to get them.)"
-    exit 1
+    if [[ -z "${slurm_account}" ]]; then
+        echo "Error: detected Slurm, but this cluster is not supposed to run Slurm." >&2
+        exit 1
+    fi
+    sacctmgr --immediate --quiet add user name="${username}" defaultaccount="${slurm_account}"
+    if [[ $? -ne 0 ]]; then
+        echo "Error: could not add Slurm user - are you a Slurm operator?" >&2
+        exit 1
+    fi
 else
     echo "Error: no mechanism for adding users found." >&2
     exit 1

--- a/createuser
+++ b/createuser
@@ -55,7 +55,7 @@ case "$cluster_name" in
         slurm_account="allusers"
         ;;
     "michael"|"young")
-        echo "Error: this is not the correct way to add users to the Thomas and Michael clusters." >&2
+        echo "Error: this is not the correct way to add users to the Young and Michael clusters." >&2
         exit 1
         ;;
     *)

--- a/lquota
+++ b/lquota
@@ -608,38 +608,23 @@ function __main() {
     local pool_display_order=("home" "scratch" "lustre")
 
     case "$clustername" in
-        "legion")
-            msg debug "using settings for legion"
-            local quota_mode="project"
-            local -A pools=([home]="/home/%username%" [scratch]="/scratch/scratch/%username%")
-            local default_pool="scratch"
-            ;;
         "myriad")
             msg debug "using settings for myriad"
             local quota_mode="project"
             local -A pools=([home]="/home/%username%" [scratch]="/scratch/scratch/%username%")
             local default_pool="scratch"
             ;;
-        "grace")
-            msg debug "using settings for grace"
-            # Grace has home and scratch but only home has quotas enabled
-            local quota_mode="user"
-            local -A pools=([home]="/home/%username%")
-            local default_pool="home"
-            ;;
-        "thomas")
-            msg debug "using settings for thomas"
-            # The version of Lustre on Thomas is too old to support projects,
-            #  so we have a single quota that encompasses both home and Scratch
-            #  spaces.
-            local quota_mode="user"
-            local -A pools=([lustre]="/scratch")
-            local default_pool="lustre"
-            ;;
         "kathleen")
             msg debug "using settings for kathleen"
             # Kathleen's new Lustre uses project quotas,
             # but no separate quotas for home and scratch
+            local quota_mode="project"
+            local -A pools=([lustre]="/home/%username%")
+            local default_pool="lustre"
+            ;;
+        dev-?)
+            msg debug "using settings for hydra"
+            # like Kathleen
             local quota_mode="project"
             local -A pools=([lustre]="/home/%username%")
             local default_pool="lustre"


### PR DESCRIPTION
In `createuser`:
* add Slurm user with `allusers` as DefaultAccount
* some cleanup, like removing obsolete clusters

In `checkuser`:
* implement the equivalents of the SGE checks
* make sure only SGE or Slurm checks are called based on the environment

In `lquota`:
* remove obsolete clusters

**Note**: So far `createuser` only adds the user to Slurm, it doesn't add them to the AD group. I'm not sure if this should be done here, or maybe via some central job (perhaps to avoid proliferation of the AD credentials).